### PR TITLE
add from email / from name field

### DIFF
--- a/Admin/EmailTemplateAdmin.php
+++ b/Admin/EmailTemplateAdmin.php
@@ -13,6 +13,12 @@ class EmailTemplateAdmin extends Admin
 {
     protected $baseRouteName = 'email_template';
     protected $baseRoutePattern = 'email_template';
+    protected $locales;
+
+    public function setLocales(array $locales)
+    {
+        $this->locales = $locales;
+    }
 
     //show
     protected function configureShowField(ShowMapper $showMapper)
@@ -28,23 +34,35 @@ class EmailTemplateAdmin extends Admin
     //add
     protected function configureFormFields(FormMapper $formMapper)
     {
-        $type = new CallbackType(function($builder) {
-            $builder->add('subject', 'text', array(
-                'label' => 'Subject'
-            ));
-            $builder->add('body', 'textarea', array(
-                'label' => 'Body'
-            ));
-        });
-
         $formMapper
             ->with('Email Templates')
                 ->add('name')
-                ->add('translationProxies', 'collection', array(
-                    'type' => $type
-                ))
             ->end()
-        ;
+            ;
+
+        $locales = $this->locales;
+
+        foreach ($locales as $locale) {
+            $formMapper
+                ->with(sprintf("Subject", $locale))
+                    ->add(sprintf("translationProxies_%s_subject", $locale), 'text', array(
+                        'label' => $locale,
+                        'property_path' => sprintf('translationProxies[%s].subject', $locale),
+                    ))
+                ->end()
+                ;
+        }
+
+        foreach ($locales as $locale) {
+            $formMapper
+                ->with(sprintf("Body", $locale))
+                    ->add(sprintf("translationProxies_%s_body", $locale), 'textarea', array(
+                        'label' => $locale,
+                        'property_path' => sprintf('translationProxies[%s].body', $locale),
+                    ))
+                ->end()
+                ;
+        }
     }
 
     //list

--- a/Admin/EmailTemplateAdmin.php
+++ b/Admin/EmailTemplateAdmin.php
@@ -63,6 +63,30 @@ class EmailTemplateAdmin extends Admin
                 ->end()
                 ;
         }
+
+        foreach ($locales as $locale) {
+            $formMapper
+                ->with(sprintf("From name", $locale))
+                    ->add(sprintf("translationProxies_%s_fromName", $locale), 'text', array(
+                        'label' => $locale,
+                        'property_path' => sprintf('translationProxies[%s].fromName', $locale),
+                        'required' => false,
+                    ))
+                ->end()
+                ;
+        }
+
+        foreach ($locales as $locale) {
+            $formMapper
+                ->with(sprintf("From email", $locale))
+                    ->add(sprintf("translationProxies_%s_fromEmail", $locale), 'email', array(
+                        'label' => $locale,
+                        'property_path' => sprintf('translationProxies[%s].fromEmail', $locale),
+                        'required' => false,
+                    ))
+                ->end()
+                ;
+        }
     }
 
     //list

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,6 +19,8 @@ class Configuration implements ConfigurationInterface
         $rootNode->children()
             ->scalarNode('custom_loader')->defaultValue(true)->end()
             ->scalarNode('default_locale')->defaultValue('en')->end()
+            ->scalarNode('default_from_name')->defaultNull()->end()
+            ->scalarNode('default_from_email')->defaultNull()->end()
             ->arrayNode('locales')
                 ->isRequired()
                 ->prototype('scalar')->end()

--- a/DependencyInjection/RjEmailExtension.php
+++ b/DependencyInjection/RjEmailExtension.php
@@ -23,6 +23,8 @@ class RjEmailExtension extends Extension
         $container->setParameter('rj_email.default_locale', $config['default_locale']);
         $container->setParameter('rj_email.locales', $config['locales']);
         $container->setParameter('rj_email.emails', $config['emails']);
+        $container->setParameter('rj_email.default_from_name', $config['default_from_name']);
+        $container->setParameter('rj_email.default_from_email', $config['default_from_email']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/Entity/EmailTemplate.php
+++ b/Entity/EmailTemplate.php
@@ -61,9 +61,6 @@ class EmailTemplate
      */
     private $translations;
 
-    //todo: From DIC
-    private $langs = array('en', 'fr', 'de');
-
     public function __construct()
     {
         $this->translations = new ArrayCollection;
@@ -160,13 +157,7 @@ class EmailTemplate
      */
     public function getTranslationProxies()
     {
-        $ret = array();
-
-        foreach ($this->langs as $lang) {
-            $ret[$lang] = $this->translate($lang);
-        }
-
-        return $ret;
+        return new EmailTemplateTranslationProxyProxy($this);
     }
 
     public function getEnTranslation()

--- a/Entity/EmailTemplateManager.php
+++ b/Entity/EmailTemplateManager.php
@@ -17,14 +17,19 @@ class EmailTemplateManager
     protected $router;
     protected $container;
     protected $cache;
+    protected $defaultLocale;
+    protected $defaultFromName;
+    protected $defaultFromEmail;
 
-    public function __construct(EntityManager $em, $class, RouterInterface $router, ContainerInterface $container)
+    public function __construct(EntityManager $em, $class, RouterInterface $router, ContainerInterface $container, $defaultFromName, $defaultFromEmail)
     {
         $this->em = $em;
         $this->repository = $em->getRepository($class);
         $this->class = $em->getClassMetadata($class);
         $this->router = $router;
         $this->container = $container;
+        $this->defaultFromName = $defaultFromName;
+        $this->defaultFromEmail = $defaultFromEmail;
 
         $this->cache = array();
     }
@@ -75,6 +80,8 @@ class EmailTemplateManager
         return array(
             'subject'   => $subject,
             'body'      => $body,
+            'fromName'  => $tr->getFromName() ?: $this->defaultFromName,
+            'fromEmail' => $tr->getFromEmail() ?: $this->defaultFromEmail,
         );
     }
 

--- a/Entity/EmailTemplateTranslationProxy.php
+++ b/Entity/EmailTemplateTranslationProxy.php
@@ -38,4 +38,27 @@ class EmailTemplateTranslationProxy extends TranslationProxy
 
         return $this;
     }
+
+    public function setFromEmail($fromEmail)
+    {
+        return $this->setTranslatedValue('fromEmail', $fromEmail);
+    }
+
+    /**
+     * @Email
+     */
+    public function getFromEmail()
+    {
+        return $this->getTranslatedValue('fromEmail');
+    }
+
+    public function setFromName($fromName)
+    {
+        return $this->setTranslatedValue('fromName', $fromName);
+    }
+
+    public function getFromName()
+    {
+        return $this->getTranslatedValue('fromName');
+    }
 }

--- a/Entity/EmailTemplateTranslationProxyProxy.php
+++ b/Entity/EmailTemplateTranslationProxyProxy.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rj\EmailBundle\Entity;
+
+class EmailTemplateTranslationProxyProxy implements \ArrayAccess
+{
+    private $emailTemplate;
+
+    public function __construct(EmailTemplate $emailTemplate)
+    {
+        $this->emailTemplate = $emailTemplate;
+    }
+
+    public function offsetGet($locale)
+    {
+        return $this->emailTemplate->translate($locale);
+    }
+
+    public function offsetSet($locale, $value)
+    {
+    }
+
+    public function offsetExists($locale)
+    {
+        return true;
+    }
+
+    public function offsetUnset($locale)
+    {
+    }
+}
+

--- a/Form/Type/CallbackType.php
+++ b/Form/Type/CallbackType.php
@@ -23,7 +23,7 @@ class CallbackType extends AbstractType
     public function getDefaultOptions(array $options)
     {
         return array(
-            'data_class' => 'Rj\EmailBundle\Entity\EmailTemplateTranslationProxy'
+            'data_class' => null,
         );
     }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -20,6 +20,8 @@
             <argument>%rj_email.email_template_class%</argument>
 			<argument type="service" id="router" />
             <argument type="service" id="service_container" />
+            <argument>%rj_email.default_from_name%</argument>
+            <argument>%rj_email.default_from_email%</argument>
         </service>
 
         <service id="rj_email.email_template_loader" class="Rj\EmailBundle\Twig\EmailTemplateLoader">

--- a/Resources/config/sonata.xml
+++ b/Resources/config/sonata.xml
@@ -13,6 +13,9 @@
             <argument />
             <argument>Rj\EmailBundle\Entity\EmailTemplate</argument>
             <argument>RjEmailBundle:EmailTemplateAdmin</argument>
+            <call method="setLocales">
+                <argument>%rj_email.locales%</argument>
+            </call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
This makes sense, since if we are going to translate subject/body, we may want to translate from name / from email too.

The fields are optional and configuration options default_from_name and default_from_email are used when the fields aren't set.

Depends on #3
