### PR TITLE
Added ExtractVarsVisitor, for extracting variables used in a template

### DIFF
--- a/Tests/Twig/ExtractVarsVisitorTest.php
+++ b/Tests/Twig/ExtractVarsVisitorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rj\EmailBundle\Twig;
+
+use Rj\EmailBundle\Twig\ExtractVarsVisitor;
+
+/**
+ * @author Arnaud Le Blanc <arnaud.lb@gmail.com>
+ */
+class ExtractVarsVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExtractVars()
+    {
+        $loader = new \Twig_Loader_Array(array());
+        $env = new \Twig_Environment($loader);
+
+        $code = 'foo bar {{ test.bar.baz }} {{ foo.bar }} {{ foo2[bar] }} {{ test.bar.qux }}';
+        $node = $env->parse($env->tokenize($code));
+
+        $traverser = new \Twig_NodeTraverser($env);
+        $visitor = new ExtractVarsVisitor;
+        $traverser->addVisitor($visitor);
+
+        $traverser->traverse($node);
+
+        $this->assertSame(array(
+            'test' => array(
+                'bar' => array(
+                    'baz' => array(),
+                    'qux' => array(),
+                ),
+            ),
+            'foo' => array(
+                'bar' => array(),
+            ),
+            'foo2' => array(
+                '...' => array(),
+            ),
+        ), $visitor->getExtractedVars());
+    }
+}
+

--- a/Twig/ExtractVarsVisitor.php
+++ b/Twig/ExtractVarsVisitor.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Rj\EmailBundle\Twig;
+
+/**
+ * @author Arnaud Le Blanc <arnaud.lb@gmail.com>
+ */
+class ExtractVarsVisitor implements \Twig_NodeVisitorInterface
+{
+    private $stack;
+    private $vars;
+    private $currentVar;
+
+    public function __construct()
+    {
+        $this->stack = [];
+        $this->vars = [];
+        $this->currentVar = &$this->vars;
+    }
+
+    public function enterNode(\Twig_NodeInterface $node, \Twig_Environment $env)
+    {
+        $this->stack[] = $node;
+        return $node;
+    }
+
+    public function leaveNode(\Twig_NodeInterface $node, \Twig_Environment $env)
+    {
+        array_pop($this->stack);
+
+        if ($node instanceof \Twig_Node_Expression_GetAttr) {
+
+            $nameNode = $node->getNode('node');
+            if ($nameNode instanceof \Twig_Node_Expression_Name) {
+                $this->addVar($nameNode->getAttribute('name'));
+            }
+
+            $attributeNode = $node->getNode('attribute');
+            if ($attributeNode instanceof \Twig_Node_Expression_Constant) {
+                $this->addVar($attributeNode->getAttribute('value'));
+            } else {
+                $this->addVar('...');
+            }
+
+            if (!(end($this->stack) instanceof \Twig_Node_Expression_GetAttr)) {
+                $this->resetVars();
+            }
+        }
+
+        return $node;
+    }
+
+    public function getPriority()
+    {
+        return 0;
+    }
+
+    public function getExtractedVars()
+    {
+        return $this->vars;
+    }
+
+    private function addVar($name)
+    {
+        if (!isset($this->currentVar[$name])) {
+            $this->currentVar[$name] = [];
+        }
+        $this->currentVar = &$this->currentVar[$name];
+    }
+
+    private function resetVars()
+    {
+        $this->currentVar = &$this->vars;
+    }
+}
+


### PR DESCRIPTION
e.g. the following template

```
{{ name }}
{{ foo.bar.baz }}
{{ foo.bar.qux }}
```

will give the following variables:

```
{
    "name": null,
    "foo": {
        "bar": {
            "baz": null,
            "qux": null,
        }
    }
}
```

so we can pre-populate variables in the preview UI

TODO: integrate this in UI
